### PR TITLE
New: Add option to disable popup and show error inline (fixes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ It provides core [*question components*](https://github.com/adaptlearning/adapt_
 
 ## Settings
 
-**\_instructionError** (object): The Instruction Error attributes group contains values for **\_isEnabled**, **title** and **body**.
+### *course.json*
 
->**\_isEnabled** (boolean):  Turns on and off the **Instruction Error** extension. Can only be set in *course.json*.
+The following attributes, set within *course.json*, configure the defaults for **Instruction Error**.
 
->**title** (boolean):  Set the notify title for the instruction error. Can only be set in *course.json*.
+**\_instructionError** (object): The Instruction Error attributes group contains values for **\_isEnabled**, **\_disablePopup**, **title** and **body**.
 
->**body** (boolean):  Set the notify body for the instruction error, defaults to the question instruction text. Can only be set in *course.json*.
+>**\_isEnabled** (boolean):  Turns on and off the **Instruction Error** extension.
+
+>**\_disablePopup** (boolean):  When set to `true`, the **Instruction Error** popup is disabled. Instead, the instruction text is highlighted and keyboard focus moves to the instruction text. The default is `false`.
+
+>**title** (boolean):  Set the notify title for the instruction error.
+
+>**body** (boolean):  Set the notify body for the instruction error, defaults to the question instruction text.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ It provides core [*question components*](https://github.com/adaptlearning/adapt_
 
 The following attributes, set within *course.json*, configure the defaults for **Instruction Error**.
 
-**\_instructionError** (object): The Instruction Error attributes group contains values for **\_isEnabled**, **\_disablePopup**, **title** and **body**.
+**\_instructionError** (object): The Instruction Error attributes group contains values for **\_isEnabled**, **\_showAsPopup**, **title** and **body**.
 
->**\_isEnabled** (boolean):  Turns on and off the **Instruction Error** extension.
+>**\_isEnabled** (boolean): Turns on and off the **Instruction Error** extension.
 
->**\_disablePopup** (boolean):  When set to `true`, the **Instruction Error** popup is disabled. Instead, the instruction text is highlighted and keyboard focus moves to the instruction text. The default is `false`.
+>**\_showAsPopup** (boolean): When set to `true`, the **Instruction Error** will display the error in a notify popup. The default is `false`.
 
->**title** (boolean):  Set the notify title for the instruction error.
+>**title** (boolean): When using the `_showAsPopup` option, this is the notify title for the instruction error. Otherwise, this is not used.
 
->**body** (boolean):  Set the notify body for the instruction error, defaults to the question instruction text.
+>**body** (boolean): When using the `_showAsPopup` option, this is the notify body for the instruction error. Otherwise, this replaces the existing `.component__instruction` text. Defaults to the question instruction text. If instruction text is not set, a generic message is used.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The following attributes, set within *course.json*, configure the defaults for *
 No known limitations.
 
 ----------------------------
-**Framework versions:**  5.19.1+<a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a><br>
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-tutor/graphs/contributors)<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>

--- a/example.json
+++ b/example.json
@@ -1,7 +1,7 @@
 // Add to course.json
 "_instructionError": {
     "_isEnabled": true,
-    "_disablePopup": false,
+    "_showAsPopup": false,
     "title": "Instructions",
     "body": "{{#if instruction}}{{{instruction}}}{{else}}Please complete the question and then select Submit.{{/if}}"
 }

--- a/example.json
+++ b/example.json
@@ -1,6 +1,7 @@
 // Add to course.json
 "_instructionError": {
     "_isEnabled": true,
+    "_disablePopup": false,
     "title": "Instructions",
     "body": "{{#if instruction}}{{{instruction}}}{{else}}Please complete the question and then select Submit.{{/if}}"
 }

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -18,11 +18,12 @@ class InstructionError extends Backbone.Controller {
       if (!(model instanceof QuestionModel)) return;
       model.set('_canSubmit', true, { pluginName: 'InstructionError' });
       model.set('instructionInitial', model.get('instruction'));
-      model.on('change:_isComplete', this.resetInstruction.bind(this));
+      model.on('change:_isSubmitted', this.resetInstruction.bind(this));
     });
   }
 
   onInstructionError({ model }) {
+    console.log(model.toJSON());
     if (this.config._disablePopup) {
       this.showInlineError(model);
       return;

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -40,6 +40,7 @@ class InstructionError extends Backbone.Controller {
   }
 
   showInlineError(model) {
+    const data = model.toJSON();
     this.addErrorClass(model);
 
     // Update instruction text

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import a11y from 'core/js/a11y';
 import data from 'core/js/data';
 import QuestionModel from 'core/js/models/questionModel';
 import notify from 'core/js/notify';
@@ -47,8 +48,13 @@ class InstructionError extends Backbone.Controller {
       'has-error'
     ].filter(Boolean).join(' ');
     model.set('_classes', classes);
-  }
 
+    const instruction = Handlebars.compile(this.config.body)(data);
+    model.set('instruction', instruction);
+
+    const $instruction = $(`.${data._id}`).find('.component__instruction').first();
+    a11y.focusFirst($instruction, { defer: true });
+  }
 }
 
 export default new InstructionError();

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -24,16 +24,29 @@ class InstructionError extends Backbone.Controller {
   }
 
   onInstructionError({ model }) {
-    const data = model.toJSON();
-    this.showPopup(data);
+    if (this.config._disablePopup) {
+      this.showInlineError(model);
+      return;
+    }
+    this.showPopup(model);
   }
 
-  showPopup(data) {
+  showPopup(model) {
+    const data = model.toJSON();
     const notifyObject = Object.assign({}, this.config, {
       title: Handlebars.compile(this.config.title)(data),
       body: Handlebars.compile(this.config.body)(data)
     });
     notify.popup(notifyObject);
+  }
+
+  showInlineError(model) {
+    const data = model.toJSON();
+    const classes = [
+      data._classes,
+      'has-error'
+    ].filter(Boolean).join(' ');
+    model.set('_classes', classes);
   }
 
 }

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -17,6 +17,7 @@ class InstructionError extends Backbone.Controller {
     data.forEach(model => {
       if (!(model instanceof QuestionModel)) return;
       model.set('_canSubmit', true, { pluginName: 'InstructionError' });
+      model.set('instructionInitial', model.get('instruction'));
     });
   }
 
@@ -49,7 +50,8 @@ class InstructionError extends Backbone.Controller {
     ].filter(Boolean).join(' ');
     model.set('_classes', classes);
 
-    const instruction = Handlebars.compile(this.config.body)(data);
+    const dataWithInitial = Object.assign(data, { instruction: model.get('instructionInitial') });
+    const instruction = Handlebars.compile(this.config.body)(dataWithInitial);
     model.set('instruction', instruction);
 
     const $instruction = $(`.${data._id}`).find('.component__instruction').first();

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -23,7 +23,6 @@ class InstructionError extends Backbone.Controller {
   }
 
   onInstructionError({ model }) {
-    console.log(model.toJSON());
     if (this.config._disablePopup) {
       this.showInlineError(model);
       return;
@@ -42,7 +41,7 @@ class InstructionError extends Backbone.Controller {
 
   showInlineError(model) {
     const data = model.toJSON();
-    this.addErrorClass(model);
+    model.toggleClass('has-error', true);
 
     // Update instruction text
     const dataWithInitial = Object.assign(data, { instruction: model.get('instructionInitial') });
@@ -54,24 +53,8 @@ class InstructionError extends Backbone.Controller {
     a11y.focusFirst($instruction, { defer: true });
   }
 
-  addErrorClass(model) {
-    const data = model.toJSON();
-    const classes = [
-      data._classes,
-      'has-error'
-    ].filter(Boolean).join(' ');
-    model.set('_classes', classes);
-  }
-
-  removeErrorClass(model) {
-    const data = model.toJSON();
-    const classesArr = data._classes.split(' ');
-    const classes = classesArr.filter(name => name !== 'has-error').join(' ');
-    model.set('_classes', classes);
-  }
-
   resetInstruction(model) {
-    this.removeErrorClass(model);
+    model.toggleClass('has-error', false);
     model.set('instruction', model.get('instructionInitial'));
   }
 

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -50,7 +50,7 @@ class InstructionError extends Backbone.Controller {
     model.set('instruction', instruction);
 
     // Focus on instruction text element
-    const $instruction = $(`.${data._id}`).find('.component__instruction').first();
+    const $instruction = $(`[data-adapt-id=${data._id}]`).find('.component__instruction').first();
     a11y.focusFirst($instruction, { defer: true });
   }
 

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -10,7 +10,6 @@ class InstructionError extends Backbone.Controller {
   }
 
   onDataReady() {
-    this.config = Adapt.course.get('_instructionError');
     if (!this.config?._isEnabled) return;
 
     this.listenTo(Adapt, 'questionView:showInstructionError', this.onInstructionError);
@@ -20,8 +19,16 @@ class InstructionError extends Backbone.Controller {
     });
   }
 
+  get config() {
+    return Adapt.course.get('_instructionError');
+  }
+
   onInstructionError({ model }) {
     const data = model.toJSON();
+    this.showPopup(data);
+  }
+
+  showPopup(data) {
     const notifyObject = Object.assign({}, this.config, {
       title: Handlebars.compile(this.config.title)(data),
       body: Handlebars.compile(this.config.body)(data)

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -42,7 +42,6 @@ class InstructionError extends Backbone.Controller {
 
   showInlineError(model) {
     const data = model.toJSON();
-    model.toggleClass('has-error', true);
 
     // Update instruction text
     const dataWithInitial = Object.assign(data, { instruction: model.get('instructionInitial') });
@@ -55,7 +54,6 @@ class InstructionError extends Backbone.Controller {
   }
 
   resetInstruction(model) {
-    model.toggleClass('has-error', false);
     model.set('instruction', model.get('instructionInitial'));
   }
 

--- a/js/adapt-contrib-instructionError.js
+++ b/js/adapt-contrib-instructionError.js
@@ -23,11 +23,12 @@ class InstructionError extends Backbone.Controller {
   }
 
   onInstructionError({ model }) {
-    if (this.config._disablePopup) {
-      this.showInlineError(model);
+    if (this.config._showAsPopup) {
+      this.showPopup(model);
       return;
     }
-    this.showPopup(model);
+
+    this.showInlineError(model);
   }
 
   showPopup(model) {

--- a/less/instructionError.less
+++ b/less/instructionError.less
@@ -4,7 +4,7 @@
   font-weight: bold;
 
   .icon {
-    .icon-cross;
+    .icon-warning;
     margin-right: @icon-padding / 4;
   }
 }

--- a/less/instructionError.less
+++ b/less/instructionError.less
@@ -1,0 +1,10 @@
+.component.has-error:not(.is-complete) .component__instruction {
+  display: flex;
+  color: @validation-error;
+  font-weight: bold;
+
+  .icon {
+    .icon-cross;
+    margin-right: @icon-padding / 4;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-instructionError",
   "version": "2.0.3",
-  "framework": ">=5.19.1",
+  "framework": ">=5.41.11",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-instructionError",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "extension": "instructionError",

--- a/properties.schema
+++ b/properties.schema
@@ -37,7 +37,7 @@
                   "title": "Title",
                   "inputType": "Text",
                   "validators": [],
-                  "help": "Set the notify title for the instruction error"
+                  "help": "When using the 'show as popup' option, this is the notify title for the instruction error"
                 },
                 "body": {
                   "type": "string",

--- a/properties.schema
+++ b/properties.schema
@@ -21,12 +21,12 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
-                "_disablePopup": {
+                "_showAsPopup": {
                   "type": "boolean",
                   "required": false,
                   "default": false,
-                  "title": "Disable popup",
-                  "help": "When set to `true`, the instruction error popup is disabled. Instead, the instruction text is highlighted and keyboard focus moves to the instruction text. The default is `false`.",
+                  "title": "Show as popup",
+                  "help": "When set to `true`, the instruction error is shown in a notify popup. The default is `false`.",
                   "inputType": "Checkbox",
                   "validators": []
                 },
@@ -34,7 +34,7 @@
                   "type": "string",
                   "required": false,
                   "default": "Instructions",
-                  "title": "Notify Title",
+                  "title": "Title",
                   "inputType": "Text",
                   "validators": [],
                   "help": "Set the notify title for the instruction error"
@@ -43,10 +43,10 @@
                   "type": "string",
                   "required": false,
                   "default": "{{#if instruction}}{{{instruction}}}{{else}}Please complete the question and then click Submit.{{/if}}",
-                  "title": "Notify Body",
+                  "title": "Body",
                   "inputType": "Text",
                   "validators": [],
-                  "help": "Set the notify body for the instruction error, defaults to the question instruction text"
+                  "help": "When using the 'show as popup' option, this is the notify body for the instruction error. Otherwise, this replaces the existing instruction text. Defaults to the question instruction text. If instruction text is not set, a generic message is used."
                 }
               }
             }

--- a/properties.schema
+++ b/properties.schema
@@ -21,6 +21,15 @@
                   "inputType": "Checkbox",
                   "validators": []
                 },
+                "_disablePopup": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Disable popup",
+                  "help": "When set to `true`, the instruction error popup is disabled. Instead, the instruction text is highlighted and keyboard focus moves to the instruction text. The default is `false`.",
+                  "inputType": "Checkbox",
+                  "validators": []
+                },
                 "title": {
                   "type": "string",
                   "required": false,


### PR DESCRIPTION
Fixes #12 

### New
* Adds `_showAsPopup` option to enable the instruction error popup. When `false` (and by default), the error is shown inline instead.

### Dependencies
https://github.com/adaptlearning/adapt-contrib-core/pull/593 ✅ Merged
https://github.com/adaptlearning/adapt-contrib-core/pull/595 ✅ Merged

### Testing
1. In _course.json_, disable error popups as follows:

```
"_instructionError": {
    "_isEnabled": true,
    "_showAsPopup": false,
    "title": "Instructions",
    "body": "{{#if instruction}}{{{instruction}}}{{else}}Please complete the question and then select Submit.{{/if}}"
}
```
2. Click on a question's Submit button before it is ready for submission (ex. an MCQ item choice has not been made)

### Expected result
The instruction text is highlighted.

![image](https://github.com/user-attachments/assets/9860bc42-bead-4a49-bca5-56525851bd4f)

