### PR TITLE
Fix: Update package.json to fix broken GitHub releases (fix #22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,13 +50,15 @@
               "files": "migrations/*.js",
               "from": "@@CURRENT_VERSION",
               "to": "${lastRelease.version}",
-              "countMatches": true
+              "countMatches": true,
+              "allowEmptyPaths": true
             },
             {
               "files": "migrations/*.js",
               "from": "@@RELEASE_VERSION",
               "to": "${nextRelease.version}",
-              "countMatches": true
+              "countMatches": true,
+              "allowEmptyPaths": true
             }
           ]
         }


### PR DESCRIPTION
Fix #22 

### Fix
* Update semantic-release-replace-plugin action to allow empty paths